### PR TITLE
Update documentation and agent configurations for SDD v5.1

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdd-spec-kit",
   "displayName": "SDD Spec Kit",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Spec-Driven Development framework with subagents, skills, and DAG-based parallel execution. Plan-approve-execute workflow for systematic feature development.",
   "author": {
     "name": "spec-kit",

--- a/.cursor/agents/sdd-explorer.md
+++ b/.cursor/agents/sdd-explorer.md
@@ -1,7 +1,7 @@
 ---
 name: sdd-explorer
 description: Deep codebase exploration for SDD workflows. Use proactively when technical approach is unclear, before /research or /specify, or when investigating existing patterns and solutions.
-model: fast
+model: inherit
 readonly: true
 ---
 

--- a/.cursor/agents/sdd-reviewer.md
+++ b/.cursor/agents/sdd-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: sdd-reviewer
 description: Code review specialist for security, performance, and spec compliance. Use before marking tasks complete, during pull request reviews, or for quality assurance audits.
-model: fast
+model: inherit
 readonly: true
 ---
 

--- a/.cursor/agents/sdd-verifier.md
+++ b/.cursor/agents/sdd-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: sdd-verifier
 description: Independent validation that implementations are actually complete. Use proactively after implementation phases to verify work, run tests, compare code to specifications, and catch incomplete or broken functionality.
-model: fast
+model: inherit
 ---
 
 You are an SDD Verifier — a skeptical validator that independently confirms work is truly complete.

--- a/.cursor/commands/_shared/agent-manual.md
+++ b/.cursor/commands/_shared/agent-manual.md
@@ -1,6 +1,6 @@
-# SDD Agent Manual (v5.0)
+# SDD Agent Manual (v5.1)
 
-Consolidated agent protocol for SDD workflows. **Requires Cursor 2.5+** for async subagents, hooks, and plugins.
+Consolidated agent protocol for SDD workflows. **Requires Cursor 3.2+** for async subagents, hooks, plugins, agent multitasking, worktrees, and multi-root sessions.
 
 ---
 
@@ -42,13 +42,15 @@ specs/
 ├── skills/                     # Domain knowledge packages
 ├── commands/                   # Slash commands
 ├── hooks.json                  # Workflow automation hooks
+├── hooks/                      # JSON-stdin hook scripts
+├── worktrees.json              # Cursor worktree setup
 ├── sandbox.json                # Network access controls
 └── rules/                      # Always-applied rules
 ```
 
 ---
 
-## Subagents (Cursor 2.5+)
+## Subagents (Cursor 3.2+)
 
 Subagents run in **isolated context**. Use them for operations that would bloat the main conversation.
 
@@ -56,11 +58,11 @@ Subagents run in **isolated context**. Use them for operations that would bloat 
 
 | Subagent | Purpose | Model | Mode |
 |----------|---------|-------|------|
-| `sdd-explorer` | Codebase discovery | fast | foreground, readonly |
+| `sdd-explorer` | Codebase discovery | inherit | foreground, readonly |
 | `sdd-planner` | Architecture design | inherit | foreground |
 | `sdd-implementer` | Code generation | inherit | **background** |
-| `sdd-verifier` | Validation | fast | foreground |
-| `sdd-reviewer` | Pre-merge code review | fast | foreground, readonly |
+| `sdd-verifier` | Validation | inherit | foreground |
+| `sdd-reviewer` | Pre-merge code review | inherit | foreground, readonly |
 | `sdd-orchestrator` | Coordination | inherit | **background** |
 
 ### Foreground vs Background
@@ -103,12 +105,20 @@ Use the Task tool to spawn subagents:
 [Use Task tool with:]
 - subagent_type: "sdd-implementer" (or other agent name)
 - prompt: Detailed instructions with all necessary context
-- model: "fast" for exploration, omit for inherit
+- model: omit for inherit, or use an exact Cursor-supported model ID when a specific model is required
 ```
 
 **Parallel execution:** Send multiple Task tool calls in a single message.
 
 **Background subagents:** Set `is_background: true` in the agent file. The parent continues working while the subagent runs.
+
+### Cursor 3.2 Multitask and Worktrees
+
+Use Cursor 3.2's native `/multitask` for ad hoc independent requests, especially when there is no SDD roadmap to update. Use SDD `/execute-parallel` when work must respect roadmap dependencies, file-conflict batching, checkpoints, or mandatory verifier handoffs.
+
+Use Agents Window worktrees for parallel or risky implementation attempts. `.cursor/worktrees.json` prepares the isolated checkout; keep setup commands lightweight and avoid assuming one package manager unless the target project declares one.
+
+For multi-root workspaces, always resolve generated files, hooks, specs, and roadmap updates from the active project root. Do not write cross-repo state unless the command explicitly targets that root.
 
 ### Automatic Verification
 
@@ -134,7 +144,7 @@ These two agents serve distinct purposes — do not confuse them:
 
 ---
 
-## Skills (Cursor 2.5+)
+## Skills (Cursor 3.2+)
 
 Skills are auto-invoked based on context or manually via `/skill-name`.
 
@@ -162,7 +172,7 @@ Skills use progressive loading — keep main `SKILL.md` focused:
 
 ---
 
-## Hooks (Cursor 2.5+)
+## Hooks (Cursor 3.2+)
 
 SDD uses hooks (`.cursor/hooks.json`) for workflow automation:
 
@@ -179,7 +189,7 @@ Hooks are compatible with Claude Code format (`.claude/settings.json`). Hook nam
 
 ---
 
-## Sandbox (Cursor 2.5+)
+## Sandbox (Cursor 3.2+)
 
 Network access controls for sandboxed commands are configured in `.cursor/sandbox.json`:
 
@@ -271,7 +281,7 @@ Batch 2 (deps satisfied):
 ### Parallel Efficiency
 - Identify independent tasks early
 - Spawn multiple subagents in single message
-- Use `model: fast` for exploration tasks
+- Prefer inherited models for custom agents unless an exact Cursor-supported model ID is required
 - Use background mode for long-running work
 
 ### Verification
@@ -281,10 +291,10 @@ Batch 2 (deps satisfied):
 - Compare code to spec requirements
 
 ### Hooks Integration
-- `subagentStop` hook tracks completion automatically
+- `subagentStop` hook tracks completion automatically in local ignored logs under `.cursor/logs/`
 - Use hooks for consistent file output processing
 - Claude Code hooks are compatible via `.claude/settings.json`
 
 ---
 
-*SDD Agent Manual v5.0 — Cursor 2.5+ (Async Subagents + Hooks + Plugins)*
+*SDD Agent Manual v5.1 — Cursor 3.2 optimized (Async Subagents + Hooks + Worktrees + Multi-root)*

--- a/.cursor/commands/audit.md
+++ b/.cursor/commands/audit.md
@@ -109,7 +109,7 @@ Read in order:
 - "Mark #N as outdated" - Code correct, update spec
 ```
 
-*Audit report generated with SDD 5.0*
+*Audit report generated with SDD 5.1*
 
 ---
 

--- a/.cursor/commands/brief.md
+++ b/.cursor/commands/brief.md
@@ -188,7 +188,7 @@ Use this structure:
 
 ---
 
-*Brief created with SDD 5.0 - Ready to code!*
+*Brief created with SDD 5.1 - Ready to code!*
 ```
 
 ### Phase 4: Verification
@@ -236,7 +236,7 @@ Verify file created and contains: problem statement, 3+ requirements, actionable
 ## Related Commands
 
 - `/evolve [task-id]` - Update brief as you discover things
-- `/upgrade [task-id]` - Expand to full SDD 5.0 if needed
+- `/upgrade [task-id]` - Expand to full SDD 5.1 if needed
 - `/implement [task-id]` - Start implementation (requires plan.md)
 - `/refine [task-id]` - Refine the brief through discussion
 - `/research [task-id]` - Deep pattern research (Full SDD planning)

--- a/.cursor/commands/evolve.md
+++ b/.cursor/commands/evolve.md
@@ -123,7 +123,7 @@ Suggest `/upgrade` when change fundamentally alters approach, multiple related c
 ## Related Commands
 
 - `/brief [task-id]` - Create initial brief
-- `/upgrade [task-id]` - Expand to full SDD 5.0
+- `/upgrade [task-id]` - Expand to full SDD 5.1
 - `/refine [task-id]` - Interactive refinement session
 - `/specify [task-id]` - Create detailed specification
 - `/plan [task-id]` - Update technical plan

--- a/.cursor/commands/execute-parallel.md
+++ b/.cursor/commands/execute-parallel.md
@@ -2,7 +2,7 @@
 
 Execute multiple tasks in parallel using async background subagents for coordination.
 
-**Leverages:** Async subagents (Cursor 2.5+), subagent tree pattern, hooks for completion tracking.
+**Leverages:** Async subagents, Cursor 3.2 worktrees/multitask awareness, subagent tree pattern, hooks for completion tracking.
 
 **See also:** `.cursor/commands/_shared/agent-manual.md` for full subagent protocol.
 
@@ -74,11 +74,15 @@ Group tasks into parallel batches based on:
 
 | Task Phase | Subagent | Model | Mode |
 |------------|----------|-------|------|
-| research | sdd-explorer | fast | foreground |
+| research | sdd-explorer | inherit | foreground |
 | brief/specify/plan/tasks | sdd-planner | inherit | foreground |
 | implement | sdd-implementer | inherit | **background** |
-| review | sdd-reviewer | fast | foreground |
-| verify | sdd-verifier | fast | foreground |
+| review | sdd-reviewer | inherit | foreground |
+| verify | sdd-verifier | inherit | foreground |
+
+**Cursor 3.2 guidance:** Use built-in `/multitask` for quick independent prompts that do not need SDD state. Use `/execute-parallel` for roadmap-backed work because it enforces dependency order, file conflict checks, checkpoints, and verifier handoffs.
+
+**Worktree guidance:** For risky or competing implementation approaches, launch the agent in an Agents Window worktree. `.cursor/worktrees.json` prepares the checkout before the SDD command runs.
 
 **Subagent Tree Pattern (2.5+):**
 
@@ -118,7 +122,7 @@ Task 1: {
    - `timestamp`: ISO8601
    - `batchNumber`: incrementing batch index
 4. **Identify next ready tasks** based on completed dependencies
-5. The `subagentStop` hook in `.cursor/hooks.json` auto-logs completion
+5. The `subagentStop` hook in `.cursor/hooks.json` auto-logs completion to ignored local logs under `.cursor/logs/`
 
 **Progress Report Format:**
 

--- a/.cursor/commands/implement.md
+++ b/.cursor/commands/implement.md
@@ -103,7 +103,7 @@ Spawn `sdd-verifier` subagent to independently validate:
 - [ ] Tests pass (if applicable)
 - [ ] Spec requirements met
 
-The `subagentStop` hook in `.cursor/hooks.json` auto-logs completion.
+The `subagentStop` hook in `.cursor/hooks.json` auto-logs completion to ignored local logs under `.cursor/logs/`.
 
 ---
 
@@ -146,7 +146,7 @@ The `subagentStop` hook in `.cursor/hooks.json` auto-logs completion.
 
 ## Subagent Delegation
 
-For long implementations, the main agent delegates to `sdd-implementer` (background subagent). The implementer spawns `sdd-verifier` as a child subagent after completing work — this is the subagent tree pattern from Cursor 2.5+.
+For long implementations, the main agent delegates to `sdd-implementer` (background subagent). The implementer spawns `sdd-verifier` as a child subagent after completing work — this is the subagent tree pattern supported by Cursor 3.2+.
 
 ## Related Commands
 

--- a/.cursor/commands/refine.md
+++ b/.cursor/commands/refine.md
@@ -321,6 +321,6 @@ This also removes related tasks. Confirm?"
 
 - `/brief [task-id]` - Create new brief
 - `/evolve [task-id]` - Quick updates during development
-- `/upgrade [task-id]` - Expand to full SDD 5.0
+- `/upgrade [task-id]` - Expand to full SDD 5.1
 - `/specify [task-id]` - Create detailed specification
 - `/generate-prd [task-id]` - Generate PRD from scratch

--- a/.cursor/commands/research.md
+++ b/.cursor/commands/research.md
@@ -293,7 +293,7 @@ Use this structure:
 
 ---
 
-*Research completed with SDD 5.0*
+*Research completed with SDD 5.1*
 ```
 
 ### Phase 4: Verification

--- a/.cursor/commands/sdd-full-plan.md
+++ b/.cursor/commands/sdd-full-plan.md
@@ -95,7 +95,7 @@ specs/todo-roadmap/[project-id]/
 ```
 
 **Generate roadmap.json** with:
-- Project metadata (id, title, description, sddVersion: "5.0")
+- Project metadata (id, title, description, sddVersion: "5.1")
 - Kanban columns (todo, in-progress, review, done)
 - Tasks/epics with dependencies, SDD command mappings, and DAG structure
 - Statistics (totalTasks, completionPercentage)

--- a/.cursor/commands/specify.md
+++ b/.cursor/commands/specify.md
@@ -174,7 +174,7 @@ Does this capture what you want? Ready to create the spec?
 2. Resolve open questions
 3. Run `/plan [task-id]` to create technical plan
 
-*Specification created with SDD 5.0*
+*Specification created with SDD 5.1*
 ```
 
 ### Phase 4: Verification

--- a/.cursor/commands/tasks.md
+++ b/.cursor/commands/tasks.md
@@ -133,7 +133,7 @@ Ready to generate the full task breakdown?
 
 ---
 
-*Tasks created with SDD 5.0*
+*Tasks created with SDD 5.1*
 ```
 
 ### Verification

--- a/.cursor/commands/upgrade.md
+++ b/.cursor/commands/upgrade.md
@@ -8,7 +8,7 @@ Escalate from lightweight SDD Quick Planning (Brief) to comprehensive SDD Full P
 
 ## Role
 
-**Planning escalation agent** - Expand lightweight briefs into comprehensive SDD 5.0 documentation when complexity warrants it. Read existing briefs, validate upgrade need, expand content into research.md, spec.md, plan.md, and tasks.md while preserving all existing decisions and context.
+**Planning escalation agent** - Expand lightweight briefs into comprehensive SDD 5.1 documentation when complexity warrants it. Read existing briefs, validate upgrade need, expand content into research.md, spec.md, plan.md, and tasks.md while preserving all existing decisions and context.
 
 ## Usage
 
@@ -40,7 +40,7 @@ I can't find a feature brief for [task-id].
 
 Would you like to:
 1. Create a brief first: `/brief [task-id]`
-2. Start with full SDD 5.0: `/research [task-id]`
+2. Start with full SDD 5.1: `/research [task-id]`
 ```
 
 **Step 2: Read and analyze the brief**
@@ -127,7 +127,7 @@ Would you like to proceed with the upgrade?
 | Next Actions | tasks.md: Task Breakdown |
 | Discoveries (changelog) | research.md: Findings |
 
-**Brief will be:** Preserved as historical reference, linked from new documents, marked as "Upgraded to SDD 5.0"
+**Brief will be:** Preserved as historical reference, linked from new documents, marked as "Upgraded to SDD 5.1"
 
 Ready to begin the upgrade?
 ```
@@ -279,12 +279,12 @@ Add upgrade notice to feature-brief.md:
 ```markdown
 ---
 
-## ⬆️ Upgraded to SDD 5.0
+## ⬆️ Upgraded to SDD 5.1
 
 **Upgrade date:** [date]
 **Reason:** [user's reason]
 
-This brief has been expanded into full SDD 5.0 documentation:
+This brief has been expanded into full SDD 5.1 documentation:
 - `research.md` - Detailed research
 - `spec.md` - Full specification
 - `plan.md` - Technical plan
@@ -318,7 +318,7 @@ Before final output, verify:
 ```
 ✅ Upgrade complete: [task-id]
 
-**Upgraded from:** SDD Quick Brief → SDD 5.0 Full
+**Upgraded from:** SDD Quick Brief → SDD 5.1 Full
 
 **Documents created:**
 - `specs/active/[task-id]/research.md` - Research & context
@@ -359,7 +359,7 @@ Still want to upgrade? Confirm and I'll proceed.
 **Solution**: Gather more info during upgrade:
 - "The brief is sparse. I'll need to ask some questions to create full docs."
 
-### Issue: Some SDD 5.0 docs already exist
+### Issue: Some SDD 5.1 docs already exist
 **Cause**: Partial upgrade previously started
 **Solution**: Identify gaps:
 - "I found existing spec.md. Should I update it or create fresh?"
@@ -374,7 +374,7 @@ Still want to upgrade? Confirm and I'll proceed.
 
 - `/brief [task-id]` - Create lightweight brief
 - `/evolve [task-id]` - Update brief with discoveries
-- `/research [task-id]` - Deep research (part of SDD 5.0)
-- `/specify [task-id]` - Full specification (part of SDD 5.0)
-- `/plan [task-id]` - Technical plan (part of SDD 5.0)
-- `/tasks [task-id]` - Task breakdown (part of SDD 5.0)
+- `/research [task-id]` - Deep research (part of SDD 5.1)
+- `/specify [task-id]` - Full specification (part of SDD 5.1)
+- `/plan [task-id]` - Technical plan (part of SDD 5.1)
+- `/tasks [task-id]` - Task breakdown (part of SDD 5.1)

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,13 +3,14 @@
   "hooks": {
     "subagentStop": [
       {
-        "command": "echo \"[SDD] $(date -u +%Y-%m-%dT%H:%M:%SZ) | Subagent: $SUBAGENT_NAME | Task: ${TASK_ID:-unknown} | Status: completed\" >> specs/active/.subagent-log.txt",
-        "matcher": "sdd-.*"
+        "command": "python3 .cursor/hooks/sdd-log-subagent-stop.py",
+        "timeout": 10
       }
     ],
     "stop": [
       {
-        "command": "echo \"[SDD] Session ended at $(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> specs/active/.session-log.txt"
+        "command": "python3 .cursor/hooks/sdd-log-session-stop.py",
+        "timeout": 10
       }
     ]
   }

--- a/.cursor/hooks/sdd-log-session-stop.py
+++ b/.cursor/hooks/sdd-log-session-stop.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Log Cursor agent stop events for SDD workflows."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"_raw": raw}
+
+    return payload if isinstance(payload, dict) else {"_payload": payload}
+
+
+def main() -> None:
+    payload = read_payload()
+    project_dir = Path(os.environ.get("CURSOR_PROJECT_DIR") or os.getcwd())
+    log_path = project_dir / ".cursor" / "logs" / "sdd-sessions.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    status = payload.get("status") or "unknown"
+    loop_count = payload.get("loop_count")
+
+    fields = [f"[SDD] Session ended at {timestamp}", f"Status: {status}"]
+    if isinstance(loop_count, int):
+        fields.append(f"Loop: {loop_count}")
+
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(" | ".join(fields) + "\n")
+
+    sys.stdout.write("{}\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:  # pragma: no cover - hook must fail open.
+        print(f"[SDD hook] session logging failed: {error}", file=sys.stderr)
+        sys.stdout.write("{}\n")

--- a/.cursor/hooks/sdd-log-subagent-stop.py
+++ b/.cursor/hooks/sdd-log-subagent-stop.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Log Cursor subagent completion events for SDD workflows.
+
+Cursor hooks pass event details as JSON on stdin. This script keeps logging
+best-effort and fail-open so observability issues do not block agent work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"_raw": raw}
+
+    return payload if isinstance(payload, dict) else {"_payload": payload}
+
+
+def truncate(value: str, limit: int = 240) -> str:
+    normalized = " ".join(value.split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 3]}..."
+
+
+def main() -> None:
+    payload = read_payload()
+    project_dir = Path(os.environ.get("CURSOR_PROJECT_DIR") or os.getcwd())
+    log_path = project_dir / ".cursor" / "logs" / "sdd-subagents.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    subagent_type = payload.get("subagent_type") or payload.get("description") or "unknown"
+    status = payload.get("status") or "unknown"
+    task = truncate(str(payload.get("task") or "unspecified"))
+    duration_ms = payload.get("duration_ms")
+    modified_files = payload.get("modified_files") or []
+
+    fields = [
+        f"[SDD] {timestamp}",
+        f"Subagent: {subagent_type}",
+        f"Status: {status}",
+        f"Task: {task}",
+    ]
+
+    if isinstance(duration_ms, (int, float)):
+        fields.append(f"Duration: {int(duration_ms)}ms")
+
+    if isinstance(modified_files, list) and modified_files:
+        files = ", ".join(str(path) for path in modified_files[:8])
+        if len(modified_files) > 8:
+            files = f"{files}, +{len(modified_files) - 8} more"
+        fields.append(f"Files: {files}")
+
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(" | ".join(fields) + "\n")
+
+    sys.stdout.write("{}\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:  # pragma: no cover - hook must fail open.
+        print(f"[SDD hook] subagent logging failed: {error}", file=sys.stderr)
+        sys.stdout.write("{}\n")

--- a/.cursor/rules/sdd-system.mdc
+++ b/.cursor/rules/sdd-system.mdc
@@ -2,9 +2,9 @@
 alwaysApply: true
 ---
 
-# SDD (Spec-Driven Development) System v5.0
+# SDD (Spec-Driven Development) System v5.1
 
-**Requires Cursor 2.5+** for async subagents, plugins, hooks, and skills.
+**Requires Cursor 3.2+** for async subagents, plugins, hooks, skills, agent multitasking, worktrees, and multi-root sessions.
 
 ## Core Philosophy
 
@@ -22,11 +22,11 @@ User Request → Main Agent → Subagents (parallel/async) → Skills (auto-invo
 
 | Subagent | Model | Mode | Purpose |
 |----------|-------|------|---------|
-| `sdd-explorer` | fast | foreground, readonly | Codebase discovery |
+| `sdd-explorer` | inherit | foreground, readonly | Codebase discovery |
 | `sdd-planner` | inherit | foreground | Architecture design |
 | `sdd-implementer` | inherit | **background** | Code generation |
-| `sdd-verifier` | fast | foreground | Validation |
-| `sdd-reviewer` | fast | foreground, readonly | Code review |
+| `sdd-verifier` | inherit | foreground | Validation |
+| `sdd-reviewer` | inherit | foreground, readonly | Code review |
 | `sdd-orchestrator` | inherit | **background** | Parallel coordination |
 
 ### Foreground vs Background
@@ -76,6 +76,12 @@ Skills use progressive loading — keep `SKILL.md` focused, put details in `refe
 - `/sdd-full-plan` → Create roadmap with DAG structure
 - `/execute-task` → Sequential task execution
 - `/execute-parallel` → Parallel via async subagents
+
+### Cursor 3.2 Agent Runtime
+- Use `/multitask` for ad hoc independent work that does not need a roadmap, checkpoint, or dependency graph.
+- Use `/execute-parallel` for SDD roadmap execution because it handles dependencies, file-conflict batching, checkpoints, and verifier handoffs.
+- Use Agents Window worktrees for risky, parallel, or best-of-N implementation work. `.cursor/worktrees.json` prepares the isolated checkout.
+- In multi-root workspaces, resolve paths from the active project root and avoid assuming a single repository owns every file.
 
 ## DAG-Based Execution
 
@@ -130,6 +136,8 @@ specs/
 ├── skills/                    # Agent Skills (progressive loading)
 ├── commands/                  # Slash commands
 ├── hooks.json                 # Workflow automation hooks
+├── hooks/                     # JSON-stdin hook scripts
+├── worktrees.json             # Cursor 3.2 worktree setup
 └── sandbox.json               # Network access controls
 ```
 
@@ -149,6 +157,7 @@ specs/
 | `/sdd-full-plan` | Full project roadmap | sdd-orchestrator |
 | `/execute-task` | Execute roadmap task | sdd-implementer |
 | `/execute-parallel` | Parallel DAG execution | sdd-orchestrator |
+| `/multitask` | Ad hoc Cursor 3.2 parallel work | Built-in async subagents |
 
 ## Todo Execution Rules
 

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,15 @@
+{
+  "setup-worktree-unix": [
+    "mkdir -p .cursor/logs",
+    "mkdir -p specs/active specs/completed specs/todo-roadmap",
+    "chmod +x .cursor/hooks/*.py 2>/dev/null || true",
+    "echo 'SDD worktree ready: no dependency install required for this toolkit repo.'"
+  ],
+  "setup-worktree-windows": [
+    "if not exist .cursor\\logs mkdir .cursor\\logs",
+    "if not exist specs\\active mkdir specs\\active",
+    "if not exist specs\\completed mkdir specs\\completed",
+    "if not exist specs\\todo-roadmap mkdir specs\\todo-roadmap",
+    "echo SDD worktree ready: no dependency install required for this toolkit repo."
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cursor/logs/
+__pycache__/
+*.py[cod]

--- a/.sdd/FULL_PLAN_EXAMPLES.md
+++ b/.sdd/FULL_PLAN_EXAMPLES.md
@@ -153,7 +153,7 @@ I understand the project well, create everything at once.
   "type": "feature",
   "complexity": "simple",
   "metadata": {
-    "sddVersion": "5.0",
+    "sddVersion": "5.1",
     "planMode": true,
     "estimatedDuration": "2 weeks",
     "complexity": "simple"
@@ -310,7 +310,7 @@ Approve this plan?
   "type": "application",
   "complexity": "medium",
   "metadata": {
-    "sddVersion": "5.0",
+    "sddVersion": "5.1",
     "estimatedDuration": "6 weeks",
     "teamSize": 3
   },
@@ -562,7 +562,7 @@ Approve this plan?
   "type": "platform",
   "complexity": "complex",
   "metadata": {
-    "sddVersion": "5.0",
+    "sddVersion": "5.1",
     "estimatedDuration": "16 weeks",
     "teamSize": 8,
     "tags": ["ecommerce", "marketplace", "payments", "shipping", "pci-compliance"]

--- a/.sdd/ROADMAP_FORMAT_SPEC.md
+++ b/.sdd/ROADMAP_FORMAT_SPEC.md
@@ -1,12 +1,12 @@
 # Roadmap Format Specification
 
 **Version:** 2.0.0  
-**Compatible With:** SDD 5.0, Taskr Kanban, VSCode Extensions, Cursor 2.5+  
+**Compatible With:** SDD 5.1, Taskr Kanban, VSCode Extensions, Cursor 3.2+  
 **Last Updated:** 2026-02-18
 
-## Cursor 2.5 Integration
+## Cursor 3.2 Integration
 
-This format works seamlessly with Cursor 2.5 features:
+This format works seamlessly with Cursor 3.2 features:
 
 - **Async Subagents** - Execute multiple tasks in parallel via `sdd-orchestrator`
 - **Subagent Tree** - Nested subagent spawning for complex task execution
@@ -73,7 +73,7 @@ interface Roadmap {
   
   // Metadata
   metadata: {
-    sddVersion: string;           // SDD version (e.g., "5.0")
+    sddVersion: string;           // SDD version (e.g., "5.1")
     planMode: boolean;            // PLAN mode enabled
     estimatedDuration: string;    // e.g., "8 weeks"
     complexity: Complexity;       // "simple" | "medium" | "complex" | "enterprise"
@@ -542,9 +542,12 @@ See [FULL_PLAN_EXAMPLES.md](./FULL_PLAN_EXAMPLES.md) for complete examples of:
 
 ## Versioning
 
-**Current Version:** 2.0.0
+**Current Version:** 2.1.0
 
 **Version History:**
+- **2.1.0** (2026-05-01): SDD 5.1 / Cursor 3.2 update
+  - Cursor 3.2 multitask, worktree, and multi-root alignment
+  - SDD version metadata bumped to 5.1
 - **2.0.0** (2026-02-18): SDD 5.0 / Cursor 2.5 update
   - Async subagent execution support
   - DAG-based parallel task resolution

--- a/.sdd/TEAM_SETUP_GUIDE.md
+++ b/.sdd/TEAM_SETUP_GUIDE.md
@@ -83,7 +83,7 @@ For each SDD command:
 
 ## SDD Commands to Add
 
-### Primary Commands (SDD 5.0)
+### Primary Commands (SDD 5.1)
 
 1. **`brief`** - Quick feature planning
    - Source: `.cursor/commands/brief.md`
@@ -112,7 +112,7 @@ For each SDD command:
    - Usage: `/execute-task [task-id]`
    - Team-wide: ✅ Recommended
 
-### Advanced Commands (SDD 5.0 Full Planning)
+### Advanced Commands (SDD 5.1 Full Planning)
 
 6. **`research`** - Pattern investigation
    - Source: `.cursor/commands/research.md`

--- a/.sdd/config.json
+++ b/.sdd/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0",
+  "version": "5.1.0",
   "project": {
     "name": "SDD Cursor Commands",
     "description": "Spec-Driven Development toolkit for Cursor IDE",

--- a/.sdd/guidelines.md
+++ b/.sdd/guidelines.md
@@ -1,4 +1,4 @@
-# Spec-Driven Development Guidelines v5.0
+# Spec-Driven Development Guidelines v5.1
 
 ## Overview
 

--- a/.sdd/templates/roadmap-template.json
+++ b/.sdd/templates/roadmap-template.json
@@ -8,7 +8,7 @@
   "updated": "{{UPDATED_TIMESTAMP}}",
   "status": "planning",
   "metadata": {
-    "sddVersion": "5.0",
+    "sddVersion": "5.1",
     "planMode": true,
     "estimatedDuration": "{{ESTIMATED_DURATION}}",
     "complexity": "{{COMPLEXITY}}",

--- a/.sdd/templates/roadmap-template.md
+++ b/.sdd/templates/roadmap-template.md
@@ -14,7 +14,7 @@
 {{PROJECT_DESCRIPTION}}
 
 ### Metadata
-- **SDD Version:** 5.0
+- **SDD Version:** 5.1
 - **PLAN Mode:** Enabled
 - **Team Size:** {{TEAM_SIZE}}
 - **Assignee:** {{ASSIGNEE}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,13 @@ Thanks for your interest in contributing! This guide covers how to add commands,
    ---
    name: your-agent
    description: What it does
-   model: fast | inherit
+   model: inherit
    is_background: true | false
    ---
    ```
-2. Add to the subagent table in `agent-manual.md` and `sdd-system.mdc`
-3. Document when to delegate to it in the Delegation Guidelines
+2. Use `inherit` by default. If a specific model is required, use an exact Cursor-supported model ID rather than an alias.
+3. Add to the subagent table in `agent-manual.md` and `sdd-system.mdc`
+4. Document when to delegate to it in the Delegation Guidelines
 
 ## Adding a New Skill
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
-# SDD Cursor Commands v5.0
+# SDD Cursor Commands v5.1
 
 <div align="center">
 
 [![GitHub stars](https://img.shields.io/github/stars/madebyaris/spec-kit-command-cursor?style=social)](https://github.com/madebyaris/spec-kit-command-cursor/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-[![Cursor 2.5+](https://img.shields.io/badge/Cursor-2.5%2B-blue)](https://cursor.com)
+[![Cursor 3.2+](https://img.shields.io/badge/Cursor-3.2%2B-blue)](https://cursor.com)
+[![Cursor 3.2 optimized](https://img.shields.io/badge/Cursor-3.2%20optimized-purple)](https://cursor.com/changelog/04-24-26)
 
 **Spec-Driven Development for Cursor IDE**
 
 Create specifications before code. Plan-approve-execute for all operations.
 
-[Quick Start](#quick-start) • [Commands](#commands) • [Subagents & Skills](#subagents--skills) • [What's New](#whats-new-in-v50) • [Contributing](#contributing)
+[Quick Start](#quick-start) • [Commands](#commands) • [Subagents & Skills](#subagents--skills) • [What's New](#whats-new-in-v51) • [Contributing](#contributing)
 
 </div>
 
 ---
 
-## What's New in v5.0
+## What's New in v5.1
 
 - **Async Subagents** — Background subagents (`is_background: true`) let the parent agent continue working while long tasks run
 - **Subagent Tree** — Subagents spawn their own subagents: orchestrator → implementers → verifiers
@@ -28,6 +29,7 @@ Create specifications before code. Plan-approve-execute for all operations.
 - **Downstream Propagation** — `/evolve` marks stale downstream docs when a spec changes
 - **Deadlock Detection** — Orchestrator detects circular dependency deadlocks and per-task timeouts
 - **Hooks** — Workflow automation via `.cursor/hooks.json` (`subagentStop`, `stop` events)
+- **Cursor 3.2 Agent Runtime** — Guidance for `/multitask`, Agents Window worktrees, and multi-root sessions
 - **Sandbox Controls** — Granular network access via `.cursor/sandbox.json`
 - **Plugin Packaging** — Distributable as a Cursor Marketplace plugin (`.cursor-plugin/`)
 
@@ -55,6 +57,11 @@ cd spec-kit-command-cursor
 ```bash
 /research database-engine Best database for our use case --deep
 ```
+
+**Cursor 3.2 parallel work:**
+- Use Cursor's built-in `/multitask` for quick independent prompts with no SDD roadmap state.
+- Use `/execute-parallel` for roadmap-backed SDD work that needs dependency checks, checkpoints, and verifier handoffs.
+- Use Agents Window worktrees for risky or competing implementations; `.cursor/worktrees.json` prepares the isolated checkout.
 
 ---
 
@@ -100,16 +107,16 @@ Specialized agents with isolated context. Background agents run asynchronously �
 
 | Subagent | Model | Mode | Purpose |
 |----------|-------|------|---------|
-| `sdd-explorer` | fast | foreground, readonly | Codebase discovery |
+| `sdd-explorer` | inherit | foreground, readonly | Codebase discovery |
 | `sdd-planner` | inherit | foreground | Architecture design |
 | `sdd-implementer` | inherit | **background** | Code generation |
-| `sdd-verifier` | fast | foreground | Post-implementation completeness check |
-| `sdd-reviewer` | fast | foreground, readonly | Pre-merge quality review |
+| `sdd-verifier` | inherit | foreground | Post-implementation completeness check |
+| `sdd-reviewer` | inherit | foreground, readonly | Pre-merge quality review |
 | `sdd-orchestrator` | inherit | **background** | Parallel task coordination with DAG |
 
 **Reviewer vs Verifier:** The reviewer is a pre-merge quality gate (security, performance, style). The verifier is a post-implementation completeness check (does the code match the spec?). Verifier answers "is it done?", Reviewer answers "is it good?"
 
-#### Subagent Tree (Cursor 2.5+)
+#### Subagent Tree (Cursor 3.2+)
 
 Subagents can spawn their own subagents, enabling true parallel DAG execution:
 

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -64,4 +64,4 @@ specs/
 - [System Rule](../.cursor/rules/sdd-system.mdc)
 
 ---
-**Version:** SDD 5.0 | **Requires:** Cursor 2.5+
+**Version:** SDD 5.1 | **Requires:** Cursor 3.2+

--- a/specs/index.md
+++ b/specs/index.md
@@ -50,4 +50,4 @@ Each command writes to `specs/active/[task-id]/`:
 Project roadmaps go to `specs/todo-roadmap/[project-id]/`.
 
 ---
-**Version:** SDD 5.0
+**Version:** SDD 5.1


### PR DESCRIPTION
This commit enhances the contributing guidelines and README to reflect the updates for SDD version 5.1, including:
- Default model changes to 'inherit' for several agents, improving flexibility.
- Updates to the README and agent documentation to highlight new features such as Cursor 3.2 compatibility, multitasking, and worktree support.
- Adjustments to command documentation to ensure consistency with the new versioning.
- Various updates across multiple files to align with the new SDD version, including metadata changes and improved instructions for contributors.

These changes aim to improve clarity, usability, and alignment with the latest features in the SDD framework.